### PR TITLE
Replace PNG logo asset with CSS branding

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.html text eol=lf
+*.css text eol=lf
+*.js text eol=lf

--- a/index.html
+++ b/index.html
@@ -1,0 +1,1857 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Readex+Pro:wght@160..700&family=Rubik:ital,wght@0,300..900;1,300..900&display=swap"
+      rel="stylesheet"
+    />
+    <title>FSTS Driver – Module Vitrine</title>
+    <style>
+      :root {
+        --primary: #1f2a44;
+        --accent: #f0a500;
+        --accent-soft: rgba(240, 165, 0, 0.12);
+        --background: #f8f9fb;
+        --card-bg: #ffffff;
+        --text: #1a1a1a;
+        --muted: #5f6c7b;
+        --border: rgba(31, 42, 68, 0.12);
+        --header-height: 64px;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        font-family: "Readex Pro", "Rubik", -apple-system, BlinkMacSystemFont,
+          "Segoe UI", sans-serif;
+        background: var(--background);
+        color: var(--text);
+        min-height: 100vh;
+        display: flex;
+        flex-direction: column;
+        line-height: 1.6;
+      }
+
+      header {
+        background: #ffffff;
+        color: var(--primary);
+        padding: 0.65rem 1.25rem;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.6rem;
+        position: sticky;
+        top: 0;
+        z-index: 100;
+        border-bottom: 1px solid rgba(39, 64, 96, 0.12);
+        min-height: var(--header-height);
+      }
+
+      .brand {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+      }
+
+      .brand-logo {
+        width: clamp(44px, 11vw, 62px);
+        height: clamp(44px, 11vw, 62px);
+        border-radius: 16px;
+        display: grid;
+        place-items: center;
+        font-weight: 700;
+        font-size: clamp(1.1rem, 2.5vw, 1.4rem);
+        letter-spacing: 0.08em;
+        color: #101820;
+        background: linear-gradient(135deg, #ffd15c, #ffb347);
+        box-shadow: 0 12px 26px rgba(15, 20, 35, 0.25);
+        text-transform: uppercase;
+      }
+
+      .brand-text {
+        display: flex;
+        flex-direction: column;
+        gap: 0.15rem;
+      }
+
+      .brand-text strong {
+        font-size: clamp(1.05rem, 2.2vw, 1.4rem);
+      }
+
+      .brand-text span {
+        font-size: clamp(0.78rem, 1.9vw, 0.95rem);
+        opacity: 0.85;
+      }
+
+      .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
+
+      nav.nav-wrapper {
+        display: flex;
+        gap: 0.5rem;
+        flex: 1 1 auto;
+        justify-content: flex-end;
+        align-items: center;
+        flex-wrap: wrap;
+      }
+
+      .home-section {
+        display: flex;
+        flex-direction: column;
+        gap: 3rem;
+        align-items: stretch;
+      }
+
+      .hero {
+        position: relative;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: calc(100vh - var(--header-height));
+        min-height: calc(100svh - var(--header-height));
+        padding: clamp(3rem, 7vw, 5rem) clamp(5vw, 9vw, 7rem);
+        background: linear-gradient(
+            135deg,
+            rgba(14, 21, 35, 0.9),
+            rgba(16, 25, 44, 0.65)
+          ),
+          url("https://live.staticflickr.com/65535/53187592601_ea80be9c2f_b.jpg")
+            center/cover no-repeat;
+        color: #ffffff;
+        box-shadow: inset 0 -60px 120px rgba(5, 10, 20, 0.45);
+      }
+
+      .hero::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(
+          125deg,
+          rgba(12, 20, 38, 0.85) 0%,
+          rgba(12, 20, 38, 0.5) 55%,
+          rgba(12, 20, 38, 0.2) 100%
+        );
+        pointer-events: none;
+      }
+
+      .hero-inner {
+        position: relative;
+        z-index: 1;
+        width: min(1120px, 92vw);
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        align-items: center;
+        gap: clamp(2rem, 5vw, 3.5rem);
+      }
+
+      .hero-copy {
+        display: flex;
+        flex-direction: column;
+        gap: 1.25rem;
+      }
+
+      .hero-title {
+        font-size: clamp(2rem, 4.2vw, 3rem);
+        line-height: 1.1;
+        margin: 0;
+        color: #ffffff;
+      }
+
+      .hero-text {
+        margin: 0;
+        font-size: clamp(1rem, 2.1vw, 1.2rem);
+        color: rgba(255, 255, 255, 0.92);
+      }
+
+      .hero-actions {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.6rem;
+      }
+
+      .hero-cta {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.5rem;
+        padding: 0.75rem 1.5rem;
+        border-radius: 999px;
+        border: none;
+        background: #ffcc4d;
+        color: #101820;
+        font-weight: 600;
+        font-size: 1rem;
+        cursor: pointer;
+        transition: transform 0.18s ease, box-shadow 0.18s ease;
+        box-shadow: 0 16px 32px rgba(255, 204, 77, 0.35);
+      }
+
+      .hero-cta:hover,
+      .hero-cta:focus {
+        transform: translateY(-2px);
+        box-shadow: 0 20px 44px rgba(255, 204, 77, 0.45);
+        outline: none;
+      }
+
+      .catalog-section {
+        width: 100%;
+        padding: clamp(4rem, 8vw, 6rem) 0 clamp(4rem, 8vw, 6rem);
+        background: radial-gradient(circle at top, rgba(240, 245, 255, 0.8), transparent 65%),
+          #f3f5fb;
+      }
+
+      .catalog-shell {
+        width: min(1100px, 92vw);
+        margin: 0 auto;
+        display: grid;
+        gap: clamp(2.5rem, 6vw, 3.5rem);
+      }
+
+      .catalog-header {
+        text-align: center;
+        display: grid;
+        gap: 0.75rem;
+        color: var(--primary);
+      }
+
+      .catalog-crumbs {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.35rem;
+        font-size: 0.95rem;
+        color: var(--muted);
+      }
+
+      .catalog-crumbs a {
+        color: var(--accent);
+        font-weight: 600;
+        text-decoration: none;
+      }
+
+      .catalog-crumbs a:hover,
+      .catalog-crumbs a:focus {
+        text-decoration: underline;
+        outline: none;
+      }
+
+      .catalog-title {
+        font-size: clamp(2.25rem, 4vw, 2.9rem);
+        margin: 0;
+      }
+
+      .catalog-text {
+        margin: 0;
+        color: var(--muted);
+        font-size: clamp(1rem, 2vw, 1.15rem);
+        max-width: 60ch;
+        justify-self: center;
+      }
+
+      .catalog-grid {
+        display: grid;
+        gap: clamp(1.5rem, 4vw, 2rem);
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      }
+
+      .catalog-card {
+        position: relative;
+        border: none;
+        border-radius: 1.25rem;
+        padding: 2.25rem 1.75rem;
+        background: linear-gradient(160deg, #25345b, #1a2340 60%, #12182b 100%);
+        color: #fff;
+        text-align: left;
+        cursor: pointer;
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+        display: grid;
+        gap: 0.9rem;
+      }
+
+      .catalog-card:hover,
+      .catalog-card:focus {
+        transform: translateY(-6px);
+        box-shadow: 0 20px 40px rgba(22, 30, 54, 0.35);
+        outline: none;
+      }
+
+      .catalog-card h3 {
+        font-size: 1.35rem;
+        margin: 0;
+        color: #ffdd7a;
+      }
+
+      .catalog-card p {
+        margin: 0;
+        color: rgba(255, 255, 255, 0.82);
+        font-size: 0.95rem;
+      }
+
+      .catalog-card span {
+        font-weight: 600;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        font-size: 0.95rem;
+        color: rgba(255, 255, 255, 0.9);
+      }
+
+      .hero-media {
+        position: relative;
+        display: grid;
+        place-items: center;
+      }
+
+      .hero-image-frame {
+        position: relative;
+        width: min(360px, 88%);
+        aspect-ratio: 4 / 5;
+        border-radius: 1.5rem;
+        overflow: hidden;
+        box-shadow: 0 24px 48px rgba(0, 0, 0, 0.35);
+        border: 6px solid rgba(255, 255, 255, 0.18);
+        backdrop-filter: blur(2px);
+      }
+
+      .hero-image-frame img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        display: block;
+      }
+
+      .hero-note {
+        position: absolute;
+        bottom: 8%;
+        right: 6%;
+        background: rgba(255, 255, 255, 0.95);
+        color: var(--primary);
+        border-radius: 1rem;
+        padding: 0.75rem 1rem;
+        box-shadow: 0 18px 36px rgba(15, 25, 40, 0.28);
+        display: flex;
+        flex-direction: column;
+        gap: 0.15rem;
+        max-width: 200px;
+        text-align: left;
+      }
+
+      .hero-note strong {
+        font-size: 1.6rem;
+        line-height: 1.1;
+      }
+
+      .hero-note span {
+        font-size: 0.85rem;
+        color: rgba(31, 42, 68, 0.75);
+      }
+
+      .home-body {
+        width: min(1080px, 92vw);
+        margin: 0 auto;
+        display: grid;
+        gap: 1.5rem;
+      }
+
+      .info-grid {
+        display: grid;
+        gap: 1.5rem;
+        grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+      }
+
+      .info-card {
+        background: var(--card-bg);
+        border-radius: 1rem;
+        padding: 1.75rem;
+        box-shadow: 0 20px 40px rgba(39, 64, 96, 0.08);
+        border: 1px solid rgba(39, 64, 96, 0.08);
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      .info-card p {
+        margin: 0;
+        color: var(--muted);
+      }
+
+      .info-card a {
+        color: var(--accent);
+        font-weight: 600;
+        text-decoration: none;
+      }
+
+      .info-card a:hover,
+      .info-card a:focus {
+        text-decoration: underline;
+        outline: none;
+      }
+
+      .nav-list {
+        display: flex;
+        gap: 0.6rem;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+      }
+
+      .nav-list button {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        background: #ffffff;
+        color: var(--primary);
+        border: 1px solid var(--border);
+        border-radius: 0.9rem;
+        padding: 0.45rem 0.95rem;
+        font-size: 0.88rem;
+        font-weight: 600;
+        cursor: pointer;
+        box-shadow: 0 10px 20px rgba(31, 42, 68, 0.08);
+        transition: background 0.2s ease, border-color 0.2s ease,
+          box-shadow 0.2s ease;
+      }
+
+      .nav-list button:hover,
+      .nav-list button:focus {
+        background: var(--accent-soft);
+        border-color: rgba(31, 42, 68, 0.28);
+        outline: none;
+        box-shadow: 0 14px 28px rgba(31, 42, 68, 0.12);
+      }
+
+      .nav-list button.active {
+        background: var(--accent);
+        color: #1a1a1a;
+        border-color: transparent;
+        box-shadow: 0 16px 32px rgba(240, 165, 0, 0.28);
+      }
+
+      .nav-toggle {
+        display: none;
+        position: relative;
+        width: 36px;
+        height: 36px;
+        border-radius: 999px;
+        border: 1px solid var(--border);
+        background: #ffffff;
+        color: var(--primary);
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        transition: background 0.2s ease, transform 0.2s ease;
+      }
+
+      .nav-toggle:hover,
+      .nav-toggle:focus {
+        background: var(--accent-soft);
+        outline: none;
+      }
+
+      .nav-toggle.open {
+        background: var(--accent);
+        border-color: transparent;
+        color: #1a1a1a;
+      }
+
+      .nav-toggle .nav-toggle-bar {
+        position: absolute;
+        width: 18px;
+        height: 2px;
+        background: currentColor;
+        transition: transform 0.2s ease, opacity 0.2s ease;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+      }
+
+      .nav-toggle::before,
+      .nav-toggle::after {
+        content: "";
+        position: absolute;
+        width: 18px;
+        height: 2px;
+        background: currentColor;
+        transition: transform 0.2s ease, opacity 0.2s ease;
+        top: 50%;
+        left: 50%;
+        transform-origin: center;
+      }
+
+      .nav-toggle::before {
+        transform: translate(-50%, -50%) translateY(-6px);
+      }
+
+      .nav-toggle::after {
+        transform: translate(-50%, -50%) translateY(6px);
+      }
+
+      .nav-toggle.open .nav-toggle-bar {
+        opacity: 0;
+      }
+
+      .nav-toggle.open::before {
+        transform: translate(-50%, -50%) rotate(45deg);
+      }
+
+      .nav-toggle.open::after {
+        transform: translate(-50%, -50%) rotate(-45deg);
+      }
+
+      .nav-wrapper.open {
+        display: flex;
+      }
+
+      main {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 3rem;
+        padding: 0 0 3rem;
+      }
+
+      section {
+        width: min(1080px, 92vw);
+        margin: 0 auto;
+      }
+
+      #home {
+        width: 100%;
+        margin: 0;
+        padding: 0;
+      }
+
+      h1,
+      h2,
+      h3,
+      h4 {
+        color: var(--primary);
+        margin-top: 0;
+      }
+
+      .info-section {
+        background: var(--card-bg);
+        border-radius: 1rem;
+        padding: 1.5rem;
+        box-shadow: 0 20px 40px rgba(39, 64, 96, 0.08);
+      }
+
+      .info-section + .info-section {
+        margin-top: 1.5rem;
+      }
+
+      .flow-panel {
+        background: transparent;
+        padding: 0;
+      }
+
+      #group-panel {
+        margin-top: clamp(1rem, 4vw, 2.25rem);
+      }
+
+      .filiere-grid {
+        display: grid;
+        gap: 1rem;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        margin-top: 1.5rem;
+      }
+
+      .tile {
+        background: var(--card-bg);
+        border-radius: 0.9rem;
+        padding: 1.25rem;
+        box-shadow: 0 16px 36px rgba(39, 64, 96, 0.06);
+        border: 1px solid rgba(39, 64, 96, 0.08);
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+        cursor: pointer;
+        text-align: left;
+      }
+
+      .tile:hover,
+      .tile:focus {
+        transform: translateY(-4px);
+        box-shadow: 0 22px 44px rgba(39, 64, 96, 0.12);
+        outline: none;
+      }
+
+      .tile h3 {
+        margin-bottom: 0.35rem;
+      }
+
+      .tile p {
+        margin: 0;
+        color: var(--muted);
+        font-size: 0.9rem;
+      }
+
+      .hidden {
+        display: none !important;
+      }
+
+      .breadcrumb {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-size: 0.9rem;
+        flex-wrap: wrap;
+        margin-bottom: 1.25rem;
+        color: var(--muted);
+      }
+
+      .breadcrumb button {
+        background: none;
+        border: none;
+        color: var(--accent);
+        font-weight: 600;
+        cursor: pointer;
+        padding: 0;
+      }
+
+      .modules-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+        gap: 1.25rem;
+      }
+
+      .modules-set {
+        display: contents;
+      }
+
+      .module-card {
+        background: var(--card-bg);
+        border-radius: 1rem;
+        padding: 1.5rem;
+        box-shadow: 0 18px 38px rgba(39, 64, 96, 0.08);
+        border: 1px solid rgba(39, 64, 96, 0.08);
+        display: flex;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+
+      .module-card h4 {
+        margin: 0;
+        font-size: 1.1rem;
+      }
+
+      .link-list {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+      }
+
+      .link-list a {
+        color: var(--primary);
+        text-decoration: none;
+        font-weight: 600;
+        padding: 0.5rem 0.75rem;
+        background: rgba(244, 162, 97, 0.16);
+        border-radius: 0.75rem;
+        display: inline-flex;
+        align-items: center;
+        gap: 0.5rem;
+        transition: background 0.2s ease, color 0.2s ease;
+      }
+
+      .link-list a:hover,
+      .link-list a:focus {
+        background: rgba(244, 162, 97, 0.32);
+        color: #1a1a1a;
+        outline: none;
+      }
+
+      footer {
+        margin-top: auto;
+        background: #0d1526;
+        color: rgba(255, 255, 255, 0.88);
+        padding: 2.5rem 1.5rem 2rem;
+        font-size: 0.9rem;
+        border-top: 1px solid rgba(255, 255, 255, 0.08);
+      }
+
+      .footer-shell {
+        margin: 0 auto;
+        width: min(1080px, 92vw);
+        display: flex;
+        flex-direction: column;
+        gap: 1.75rem;
+      }
+
+      .footer-top {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+        align-items: center;
+        text-align: center;
+      }
+
+      .footer-brand {
+        display: flex;
+        align-items: center;
+        gap: 1rem;
+      }
+
+      .footer-logo {
+        width: clamp(44px, 10vw, 58px);
+        height: clamp(44px, 10vw, 58px);
+        border-radius: 16px;
+        display: grid;
+        place-items: center;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        background: linear-gradient(135deg, #ffd15c, #ffb347);
+        color: #101820;
+        box-shadow: 0 12px 26px rgba(0, 0, 0, 0.28);
+      }
+
+      .footer-text {
+        display: flex;
+        flex-direction: column;
+        gap: 0.2rem;
+      }
+
+      .footer-text span:first-child {
+        font-weight: 600;
+        font-size: 1rem;
+        color: #ffffff;
+      }
+
+      .footer-text span:last-child {
+        color: rgba(255, 255, 255, 0.7);
+        font-size: 0.85rem;
+      }
+
+      .footer-links {
+        display: flex;
+        gap: 1rem;
+        flex-wrap: wrap;
+        justify-content: center;
+      }
+
+      .footer-links a {
+        color: rgba(255, 255, 255, 0.82);
+        text-decoration: none;
+        font-weight: 500;
+        font-size: 0.92rem;
+        padding: 0.25rem 0.5rem;
+        transition: color 0.2s ease;
+      }
+
+      .footer-links a:hover,
+      .footer-links a:focus {
+        color: #ffcc4d;
+        outline: none;
+      }
+
+      .footer-bottom {
+        border-top: 1px solid rgba(255, 255, 255, 0.08);
+        padding-top: 1.5rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.35rem;
+        text-align: center;
+        font-size: 0.85rem;
+        color: rgba(255, 255, 255, 0.65);
+      }
+
+      @media (min-width: 768px) {
+        .footer-top {
+          flex-direction: row;
+          justify-content: space-between;
+          align-items: center;
+          text-align: left;
+        }
+
+        .footer-brand {
+          justify-content: flex-start;
+        }
+
+        .footer-links {
+          justify-content: flex-end;
+        }
+
+        .footer-bottom {
+          flex-direction: row;
+          justify-content: space-between;
+          text-align: left;
+          gap: 1.5rem;
+        }
+      }
+
+      @media (max-width: 900px) {
+        header {
+          padding: 0.7rem 1.15rem;
+        }
+
+        .brand {
+          flex: 1;
+        }
+
+        .hero {
+          padding: 3rem 1.75rem;
+        }
+
+        .hero-inner {
+          grid-template-columns: 1fr;
+        }
+
+        .hero-media {
+          order: -1;
+          margin-bottom: 3rem;
+        }
+
+        .hero-image-frame {
+          width: min(320px, 82%);
+        }
+
+        .hero-note {
+          left: 50%;
+          right: auto;
+          bottom: 0;
+          transform: translate(-50%, 65%);
+          text-align: center;
+          padding: 0.85rem 1.1rem;
+          max-width: min(220px, 75%);
+        }
+
+        .catalog-section {
+          padding: clamp(3rem, 10vw, 4.5rem) 0 clamp(3rem, 10vw, 4.5rem);
+        }
+
+        .catalog-grid {
+          grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        }
+
+        .catalog-card {
+          padding: 1.9rem 1.5rem;
+        }
+
+        .nav-toggle {
+          display: inline-flex;
+        }
+
+        nav.nav-wrapper {
+          position: absolute;
+          top: calc(100% + 0.75rem);
+          left: 1.25rem;
+          right: 1.25rem;
+          background: #ffffff;
+          border: 1px solid rgba(39, 64, 96, 0.12);
+          border-radius: 1rem;
+          padding: 0.75rem;
+          box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+          flex-direction: column;
+          align-items: stretch;
+          gap: 0.65rem;
+          display: none;
+          z-index: 120;
+        }
+
+        nav.nav-wrapper.open {
+          display: flex;
+        }
+
+        .nav-list {
+          flex-direction: column;
+          align-items: stretch;
+          gap: 0.65rem;
+        }
+
+        .nav-list button {
+          width: 100%;
+          justify-content: flex-start;
+          font-size: 1rem;
+          padding: 0.75rem 0.95rem;
+          box-shadow: none;
+          border-radius: 0.95rem;
+        }
+
+        .nav-list button:hover,
+        .nav-list button:focus {
+          box-shadow: none;
+        }
+
+        .nav-list button.active {
+          box-shadow: none;
+        }
+
+        .modules-grid {
+          grid-template-columns: 1fr;
+        }
+
+        .filiere-grid {
+          grid-template-columns: 1fr;
+        }
+
+        .info-section {
+          padding: 1.25rem;
+        }
+      }
+
+      @media (max-width: 480px) {
+        header {
+          padding: 0.6rem 0.9rem;
+        }
+
+        .brand-text span {
+          font-size: 0.78rem;
+        }
+
+        .hero {
+          padding: 2.75rem 1.25rem;
+        }
+
+        .hero-title {
+          font-size: 2.1rem;
+        }
+
+        .catalog-card {
+          padding: 1.75rem 1.35rem;
+        }
+
+        .breadcrumb {
+          font-size: 0.85rem;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="brand">
+        <span class="brand-logo" aria-hidden="true">FD</span>
+        <div class="brand-text">
+          <strong>FSTS Driver</strong>
+          <span>Modules &amp; Resources Library</span>
+        </div>
+      </div>
+      <button
+        type="button"
+        class="nav-toggle"
+        id="nav-toggle"
+        aria-expanded="false"
+        aria-controls="primary-nav"
+      >
+        <span class="nav-toggle-bar" aria-hidden="true"></span>
+        <span class="sr-only">Ouvrir le menu</span>
+      </button>
+      <nav
+        aria-label="Navigation principale"
+        class="nav-wrapper"
+        id="primary-nav"
+      >
+        <div class="nav-list">
+          <button
+            type="button"
+            class="nav-btn active"
+            data-target="home"
+            aria-pressed="true"
+          >
+            Accueil
+          </button>
+          <button type="button" class="nav-btn" data-target="tronc-commun">
+            Tronc commun
+          </button>
+          <button type="button" class="nav-btn" data-target="licence">
+            Licence
+          </button>
+          <button type="button" class="nav-btn" data-target="master">
+            Master
+          </button>
+          <button type="button" class="nav-btn" data-target="ingenieur">
+            Cycle d’ingénieur
+          </button>
+        </div>
+      </nav>
+    </header>
+
+    <main>
+      <section id="home" class="home-section">
+        <div class="hero">
+          <div class="hero-inner">
+            <div class="hero-copy">
+              <h1 class="hero-title">Bienvenue sur FSTS Driver</h1>
+              <p class="hero-text">
+                La plateforme qui regroupe l’ensemble des cours, TDs, TPs et
+                ressources pédagogiques de la Faculté des Sciences et Techniques
+                de Settat.<br />
+                Accédez facilement aux liens Google Drive classés par filière.
+              </p>
+              <div class="hero-actions">
+                <button
+                  type="button"
+                  class="hero-cta"
+                  id="hero-cta"
+                  aria-controls="catalog"
+                >
+                  Explorer les filières
+                </button>
+              </div>
+            </div>
+            <div class="hero-media">
+              <div class="hero-image-frame">
+                <img
+                  src="https://live.staticflickr.com/65535/53187592601_ea80be9c2f_b.jpg"
+                  alt="Aperçu des ressources pédagogiques FSTS"
+                  loading="lazy"
+                />
+              </div>
+              <div class="hero-note">
+                <strong>+120</strong>
+                <span>Ressources partagées par la communauté</span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="home-body">
+          <div class="info-grid">
+            <article class="info-card">
+              <h2>WHY THIS WEBSITE?</h2>
+              <p>
+                Centraliser les supports de cours pour toutes les filières.
+                Chaque carte de module vous mène directement aux ressources
+                partagées sur Google Drive : PDF, diapositives, vidéos et
+                dossiers.
+              </p>
+            </article>
+            <article class="info-card">
+              <h2>BUILT BY WHO?</h2>
+              <p>
+                Créé par des étudiants passionnés souhaitant partager leurs
+                ressources avec la communauté FSTS. Ensemble, nous construisons
+                une base de connaissances commune.
+              </p>
+            </article>
+            <article class="info-card" id="contact">
+              <h2>CONTACT ME</h2>
+              <p>
+                Une suggestion, un fichier manquant ou une mise à jour ? Écrivez
+                à
+                <a href="mailto:contact@fstsdriver.example"
+                  >contact@fstsdriver.example</a
+                >
+                ou partagez vos ressources.
+              </p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section
+        id="catalog"
+        class="catalog-section hidden"
+        aria-labelledby="catalog-title"
+      >
+        <div class="catalog-shell">
+          <div class="catalog-header">
+            <div class="catalog-crumbs">
+              <a href="#" id="catalog-home">Accueil</a>
+              <span aria-hidden="true">/</span>
+              <span>Nos Filières</span>
+            </div>
+            <h2 id="catalog-title" class="catalog-title">Nos Filières</h2>
+            <p class="catalog-text">
+              Choisissez une filière pour consulter les modules et ressources
+              partagés avec la communauté FSTS.
+            </p>
+          </div>
+          <div class="catalog-grid" role="list">
+            <button type="button" class="catalog-card" data-group="tronc-commun">
+              <h3>Tronc commun</h3>
+              <p>Analyse, programmation et bases scientifiques.</p>
+              <span>Voir les ressources →</span>
+            </button>
+            <button type="button" class="catalog-card" data-group="licence">
+              <h3>Licence Sciences et Techniques</h3>
+              <p>Filières professionnelles et fondamentales.</p>
+              <span>Voir les ressources →</span>
+            </button>
+            <button type="button" class="catalog-card" data-group="master">
+              <h3>Master Sciences et Techniques</h3>
+              <p>Spécialisations avancées et projets.</p>
+              <span>Voir les ressources →</span>
+            </button>
+            <button type="button" class="catalog-card" data-group="ingenieur">
+              <h3>Cycle d’ingénieur</h3>
+              <p>Formation d’ingénieur et expertise technique.</p>
+              <span>Voir les ressources →</span>
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <section
+        id="group-panel"
+        class="info-section flow-panel hidden"
+        aria-live="polite"
+      >
+        <div class="breadcrumb" id="breadcrumb">
+          <button type="button" id="breadcrumb-home">Accueil</button>
+          <span aria-hidden="true" id="breadcrumb-sep">›</span>
+          <button type="button" id="breadcrumb-group"></button>
+          <span id="breadcrumb-filiere" class="hidden"></span>
+        </div>
+
+        <div id="filiere-view" class="filiere-grid hidden" role="list">
+          <button
+            type="button"
+            class="tile"
+            data-group="tronc-commun"
+            data-filiere="maths-fondamentales"
+          >
+            <h3>Mathématiques Fondamentales</h3>
+            <p>Analyse, algèbre et outils de base.</p>
+          </button>
+          <button
+            type="button"
+            class="tile"
+            data-group="tronc-commun"
+            data-filiere="informatique-intro"
+          >
+            <h3>Informatique Intro</h3>
+            <p>Programmation et structures de données.</p>
+          </button>
+          <button
+            type="button"
+            class="tile"
+            data-group="licence"
+            data-filiere="gi"
+          >
+            <h3>Génie Informatique (GI)</h3>
+            <p>Développement logiciel et systèmes.</p>
+          </button>
+          <button
+            type="button"
+            class="tile"
+            data-group="licence"
+            data-filiere="gc"
+          >
+            <h3>Génie Civil (GC)</h3>
+            <p>Structures, matériaux et topographie.</p>
+          </button>
+          <button
+            type="button"
+            class="tile"
+            data-group="master"
+            data-filiere="msd"
+          >
+            <h3>Management des Systèmes Décisionnels (MSD)</h3>
+            <p>Business intelligence et gouvernance.</p>
+          </button>
+          <button
+            type="button"
+            class="tile"
+            data-group="master"
+            data-filiere="sitd"
+          >
+            <h3>
+              Sécurité &amp; Ingénierie des Technologies de Données (SITD)
+            </h3>
+            <p>Sécurité, Big Data et infrastructures.</p>
+          </button>
+          <button
+            type="button"
+            class="tile"
+            data-group="ingenieur"
+            data-filiere="imi"
+          >
+            <h3>Ingénierie Mécatronique et Industrielle (IMI)</h3>
+            <p>Automatisation et robotique.</p>
+          </button>
+          <button
+            type="button"
+            class="tile"
+            data-group="ingenieur"
+            data-filiere="irssi"
+          >
+            <h3>Ingénierie des Réseaux et Systèmes Sécurisés (IRSSI)</h3>
+            <p>Systèmes, réseaux et cybersécurité.</p>
+          </button>
+          <button
+            type="button"
+            class="tile"
+            data-group="ingenieur"
+            data-filiere="qhse"
+          >
+            <h3>Qualité, Hygiène, Sécurité, Environnement (QHSE)</h3>
+            <p>Gestion des risques et conformité.</p>
+          </button>
+        </div>
+
+        <div id="modules-view" class="modules-grid hidden" role="list">
+          <section
+            class="modules-set hidden"
+            data-group="tronc-commun"
+            data-filiere="maths-fondamentales"
+          >
+            <article class="module-card">
+              <h4>Analyse I</h4>
+              <div class="link-list">
+                <a
+                  href="https://drive.google.com/file/d/1aExampleMathAnalyse1/view"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >📄 Cours PDF – Analyse I</a
+                >
+                <a
+                  href="https://drive.google.com/file/d/1bExampleMathAnalyse1TD/view"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >📝 TD – Analyse I</a
+                >
+              </div>
+            </article>
+            <article class="module-card">
+              <h4>Algorithmique I</h4>
+              <div class="link-list">
+                <a
+                  href="https://drive.google.com/file/d/1cExampleAlgoCours/view"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >📄 Cours PDF – Algorithmique I</a
+                >
+                <a
+                  href="https://drive.google.com/file/d/1dExampleAlgoTP/view"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >💻 TP – Algorithmique I</a
+                >
+              </div>
+            </article>
+            <article class="module-card">
+              <h4>Physique Générale</h4>
+              <div class="link-list">
+                <a
+                  href="https://drive.google.com/file/d/1eExamplePhysique/view"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >📽️ Vidéo – Cinématique</a
+                >
+              </div>
+            </article>
+          </section>
+
+          <section
+            class="modules-set hidden"
+            data-group="tronc-commun"
+            data-filiere="informatique-intro"
+          >
+            <article class="module-card">
+              <h4>Programmation C</h4>
+              <div class="link-list">
+                <a
+                  href="https://drive.google.com/file/d/1fExampleProgC/view"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >📄 Cours PDF – Programmation C</a
+                >
+                <a
+                  href="https://drive.google.com/drive/folders/1gExampleProgCFolder"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >📁 Dossier – Exercices et corrections</a
+                >
+              </div>
+            </article>
+            <article class="module-card">
+              <h4>Architecture des Ordinateurs</h4>
+              <div class="link-list">
+                <a
+                  href="https://drive.google.com/file/d/1hExampleArchCours/view"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >📊 Slides – Architecture</a
+                >
+              </div>
+            </article>
+          </section>
+
+          <section
+            class="modules-set hidden"
+            data-group="licence"
+            data-filiere="gi"
+          >
+            <article class="module-card">
+              <h4>Structures de Données Avancées</h4>
+              <div class="link-list">
+                <a
+                  href="https://drive.google.com/file/d/2aExampleSDA/view"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >📄 Cours PDF – Structures de Données</a
+                >
+                <a
+                  href="https://drive.google.com/file/d/2bExampleSDA/view"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >📝 TD – Listes et arbres</a
+                >
+              </div>
+            </article>
+            <article class="module-card">
+              <h4>Développement Web</h4>
+              <div class="link-list">
+                <a
+                  href="https://drive.google.com/file/d/2cExampleWebSlides/view"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >📊 Slides – HTML &amp; CSS</a
+                >
+                <a
+                  href="https://drive.google.com/drive/folders/2dExampleWebFolder"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >📁 Dossier – Projets</a
+                >
+              </div>
+            </article>
+            <article class="module-card">
+              <h4>Bases de Données</h4>
+              <div class="link-list">
+                <a
+                  href="https://drive.google.com/file/d/2eExampleBDD/view"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >📄 Cours PDF – SQL</a
+                >
+                <a
+                  href="https://drive.google.com/file/d/2fExampleBDDTP/view"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >🧪 TP – Modélisation</a
+                >
+              </div>
+            </article>
+          </section>
+
+          <section
+            class="modules-set hidden"
+            data-group="licence"
+            data-filiere="gc"
+          >
+            <article class="module-card">
+              <h4>Mécanique des Structures</h4>
+              <div class="link-list">
+                <a
+                  href="https://drive.google.com/file/d/2gExampleMeca/view"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >📄 Cours PDF – Mécanique</a
+                >
+              </div>
+            </article>
+            <article class="module-card">
+              <h4>Résistance des Matériaux</h4>
+              <div class="link-list">
+                <a
+                  href="https://drive.google.com/file/d/2hExampleRDM/view"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >📊 Slides – RDM</a
+                >
+              </div>
+            </article>
+            <article class="module-card">
+              <h4>Topographie</h4>
+              <div class="link-list">
+                <a
+                  href="https://drive.google.com/drive/folders/2iExampleTopoFolder"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >📁 Dossier – Travaux pratiques</a
+                >
+              </div>
+            </article>
+          </section>
+
+          <section
+            class="modules-set hidden"
+            data-group="master"
+            data-filiere="msd"
+          >
+            <article class="module-card">
+              <h4>Data Warehouse</h4>
+              <div class="link-list">
+                <a
+                  href="https://drive.google.com/file/d/3aExampleDW/view"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >📄 Cours PDF – Modélisation multidimensionnelle</a
+                >
+                <a
+                  href="https://drive.google.com/file/d/3bExampleDWTP/view"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >🧪 TP – ETL avec Talend</a
+                >
+              </div>
+            </article>
+            <article class="module-card">
+              <h4>Data Mining</h4>
+              <div class="link-list">
+                <a
+                  href="https://drive.google.com/file/d/3cExampleDM/view"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >📊 Slides – Classification</a
+                >
+                <a
+                  href="https://drive.google.com/drive/folders/3dExampleDMFolder"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >📁 Dossier – Jeux de données</a
+                >
+              </div>
+            </article>
+          </section>
+
+          <section
+            class="modules-set hidden"
+            data-group="master"
+            data-filiere="sitd"
+          >
+            <article class="module-card">
+              <h4>Sécurité Réseau</h4>
+              <div class="link-list">
+                <a
+                  href="https://drive.google.com/file/d/3eExampleSecReseau/view"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >📄 Cours PDF – Sécurité réseau</a
+                >
+                <a
+                  href="https://drive.google.com/file/d/3fExampleSecLab/view"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >🧪 TP – Pare-feux</a
+                >
+              </div>
+            </article>
+            <article class="module-card">
+              <h4>Big Data Processing</h4>
+              <div class="link-list">
+                <a
+                  href="https://drive.google.com/drive/folders/3gExampleBigData"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >📁 Dossier – TP Spark</a
+                >
+              </div>
+            </article>
+          </section>
+
+          <section
+            class="modules-set hidden"
+            data-group="ingenieur"
+            data-filiere="imi"
+          >
+            <article class="module-card">
+              <h4>Automatique Avancée</h4>
+              <div class="link-list">
+                <a
+                  href="https://drive.google.com/file/d/4aExampleAuto/view"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >📄 Cours PDF – Automatique</a
+                >
+                <a
+                  href="https://drive.google.com/file/d/4bExampleAuto/view"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >📊 Slides – Commande PID</a
+                >
+              </div>
+            </article>
+            <article class="module-card">
+              <h4>Robotique</h4>
+              <div class="link-list">
+                <a
+                  href="https://drive.google.com/drive/folders/4cExampleRobot"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >📁 Dossier – Projets</a
+                >
+              </div>
+            </article>
+          </section>
+
+          <section
+            class="modules-set hidden"
+            data-group="ingenieur"
+            data-filiere="irssi"
+          >
+            <article class="module-card">
+              <h4>Administration Système Avancée</h4>
+              <div class="link-list">
+                <a
+                  href="https://drive.google.com/file/d/4dExampleSysAdmin/view"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >📄 Cours PDF – Linux avancé</a
+                >
+              </div>
+            </article>
+            <article class="module-card">
+              <h4>Audit de Sécurité</h4>
+              <div class="link-list">
+                <a
+                  href="https://drive.google.com/drive/folders/4eExampleAudit"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >📁 Dossier – Guides d’audit</a
+                >
+                <a
+                  href="https://drive.google.com/file/d/4fExampleAuditSlides/view"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >📊 Slides – Outils et méthodologie</a
+                >
+              </div>
+            </article>
+          </section>
+
+          <section
+            class="modules-set hidden"
+            data-group="ingenieur"
+            data-filiere="qhse"
+          >
+            <article class="module-card">
+              <h4>Management QSE</h4>
+              <div class="link-list">
+                <a
+                  href="https://drive.google.com/file/d/4gExampleQSE/view"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >📄 Cours PDF – Normes ISO</a
+                >
+              </div>
+            </article>
+            <article class="module-card">
+              <h4>Gestion de Crise</h4>
+              <div class="link-list">
+                <a
+                  href="https://drive.google.com/file/d/4hExampleCrisis/view"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >🎥 Vidéo – Gestion d’incident</a
+                >
+              </div>
+            </article>
+          </section>
+        </div>
+      </section>
+    </main>
+
+    <footer>
+      <div class="footer-shell">
+        <div class="footer-top">
+          <div class="footer-brand">
+            <span class="brand-logo footer-logo" aria-hidden="true">FD</span>
+            <div class="footer-text">
+              <span>FSTS Driver</span>
+              <span>Modules &amp; Resources Library</span>
+            </div>
+          </div>
+          <nav class="footer-links" aria-label="Liens secondaires">
+            <a href="#home">Accueil</a>
+            <a href="#catalog">Filières</a>
+            <a href="#contact">Contact</a>
+          </nav>
+        </div>
+        <div class="footer-bottom">
+          <span
+            >© <span id="year"></span> Ressources partagées par la communauté.</span
+          >
+          <span>Conçu avec passion pour la communauté FSTS.</span>
+        </div>
+      </div>
+    </footer>
+
+    <script>
+      const navButtons = Array.from(document.querySelectorAll(".nav-btn"));
+      const navWrapper = document.getElementById("primary-nav");
+      const navToggle = document.getElementById("nav-toggle");
+      const navToggleLabel = navToggle
+        ? navToggle.querySelector(".sr-only")
+        : null;
+      const homeSection = document.getElementById("home");
+      const catalogSection = document.getElementById("catalog");
+      const catalogHomeLink = document.getElementById("catalog-home");
+      const catalogCards = Array.from(
+        document.querySelectorAll(".catalog-card")
+      );
+      const groupPanel = document.getElementById("group-panel");
+      const filiereView = document.getElementById("filiere-view");
+      const filiereTiles = Array.from(filiereView.querySelectorAll(".tile"));
+      const modulesView = document.getElementById("modules-view");
+      const moduleSets = Array.from(
+        modulesView.querySelectorAll(".modules-set")
+      );
+      const breadcrumb = document.getElementById("breadcrumb");
+      const breadcrumbHome = document.getElementById("breadcrumb-home");
+      const breadcrumbSeparator = document.getElementById("breadcrumb-sep");
+      const breadcrumbGroupBtn = document.getElementById("breadcrumb-group");
+      const breadcrumbFiliere = document.getElementById("breadcrumb-filiere");
+      const heroCta = document.getElementById("hero-cta");
+
+      const navLabels = Object.fromEntries(
+        navButtons.map((btn) => [btn.dataset.target, btn.textContent.trim()])
+      );
+
+      const state = {
+        view: "home",
+        group: null,
+        filiere: null,
+        filiereLabel: "",
+      };
+
+      function openMobileNav() {
+        if (!navWrapper || !navToggle) return;
+        navWrapper.classList.add("open");
+        navToggle.classList.add("open");
+        navToggle.setAttribute("aria-expanded", "true");
+        if (navToggleLabel) {
+          navToggleLabel.textContent = "Fermer le menu";
+        }
+      }
+
+      function closeMobileNav(shouldFocusToggle = false) {
+        if (!navWrapper || !navToggle) return;
+        navWrapper.classList.remove("open");
+        navToggle.classList.remove("open");
+        navToggle.setAttribute("aria-expanded", "false");
+        if (navToggleLabel) {
+          navToggleLabel.textContent = "Ouvrir le menu";
+        }
+        if (shouldFocusToggle) {
+          navToggle.focus();
+        }
+      }
+
+      function isMobileView() {
+        return window.innerWidth <= 900;
+      }
+
+      function setActiveNav(target) {
+        navButtons.forEach((btn) => {
+          const isActive = Boolean(target && btn.dataset.target === target);
+          btn.classList.toggle("active", isActive);
+          btn.setAttribute("aria-pressed", isActive ? "true" : "false");
+        });
+      }
+
+      function scrollToSection(section) {
+        section?.scrollIntoView({ behavior: "smooth", block: "start" });
+      }
+
+      function render() {
+        const { view, group, filiere, filiereLabel } = state;
+        const activeNav =
+          view === "home"
+            ? "home"
+            : view === "filiere" || view === "modules"
+            ? group
+            : null;
+
+        setActiveNav(activeNav);
+
+        if (view === "home") {
+          homeSection.classList.remove("hidden");
+          catalogSection?.classList.add("hidden");
+          groupPanel.classList.add("hidden");
+          breadcrumb.classList.add("hidden");
+          filiereView.classList.add("hidden");
+          modulesView.classList.add("hidden");
+          filiereTiles.forEach((tile) => tile.classList.remove("hidden"));
+          moduleSets.forEach((set) => set.classList.add("hidden"));
+          return;
+        }
+
+        homeSection.classList.add("hidden");
+
+        if (view === "catalog") {
+          catalogSection?.classList.remove("hidden");
+          groupPanel.classList.add("hidden");
+          breadcrumb.classList.add("hidden");
+          filiereView.classList.add("hidden");
+          modulesView.classList.add("hidden");
+          return;
+        }
+
+        catalogSection?.classList.add("hidden");
+        groupPanel.classList.remove("hidden");
+
+        const hasGroup = Boolean(group);
+        breadcrumb.classList.toggle("hidden", !hasGroup);
+        breadcrumbGroupBtn.classList.toggle("hidden", !hasGroup);
+        breadcrumbSeparator.classList.toggle("hidden", !hasGroup);
+
+        if (hasGroup) {
+          breadcrumbGroupBtn.textContent = navLabels[group] || "";
+        }
+
+        if (view === "filiere") {
+          filiereView.classList.remove("hidden");
+          modulesView.classList.add("hidden");
+          breadcrumbFiliere.classList.add("hidden");
+          breadcrumbFiliere.textContent = "";
+          filiereTiles.forEach((tile) => {
+            tile.classList.toggle("hidden", tile.dataset.group !== group);
+          });
+          moduleSets.forEach((set) => set.classList.add("hidden"));
+          return;
+        }
+
+        if (view === "modules") {
+          filiereView.classList.add("hidden");
+          modulesView.classList.remove("hidden");
+          breadcrumbFiliere.classList.remove("hidden");
+          breadcrumbFiliere.textContent = `› ${filiereLabel}`;
+          moduleSets.forEach((set) => {
+            const isMatch =
+              set.dataset.group === group && set.dataset.filiere === filiere;
+            set.classList.toggle("hidden", !isMatch);
+          });
+        }
+      }
+
+      function resetToHome() {
+        state.view = "home";
+        state.group = null;
+        state.filiere = null;
+        state.filiereLabel = "";
+        render();
+      }
+
+      heroCta?.addEventListener("click", () => {
+        state.view = "catalog";
+        state.group = null;
+        state.filiere = null;
+        state.filiereLabel = "";
+        render();
+        scrollToSection(catalogSection);
+        if (isMobileView()) {
+          closeMobileNav();
+        }
+      });
+
+      catalogHomeLink?.addEventListener("click", (event) => {
+        event.preventDefault();
+        resetToHome();
+        window.scrollTo({ top: 0, behavior: "smooth" });
+      });
+
+      catalogCards.forEach((card) => {
+        card.addEventListener("click", () => {
+          const groupKey = card.dataset.group;
+          if (!groupKey) return;
+          state.view = "filiere";
+          state.group = groupKey;
+          state.filiere = null;
+          state.filiereLabel = "";
+          render();
+          scrollToSection(groupPanel);
+        });
+      });
+
+      navButtons.forEach((button) => {
+        button.addEventListener("click", () => {
+          const target = button.dataset.target;
+          if (target === "home") {
+            resetToHome();
+            window.scrollTo({ top: 0, behavior: "smooth" });
+          } else {
+            state.view = "filiere";
+            state.group = target;
+            state.filiere = null;
+            state.filiereLabel = "";
+            render();
+            scrollToSection(groupPanel);
+          }
+          if (isMobileView()) {
+            closeMobileNav();
+          }
+        });
+      });
+
+      if (navToggle) {
+        navToggle.addEventListener("click", () => {
+          const expanded = navToggle.getAttribute("aria-expanded") === "true";
+          if (expanded) {
+            closeMobileNav();
+          } else {
+            openMobileNav();
+          }
+        });
+      }
+
+      window.addEventListener("resize", () => {
+        if (!isMobileView()) {
+          closeMobileNav();
+        }
+      });
+
+      document.addEventListener("keydown", (event) => {
+        if (
+          event.key === "Escape" &&
+          navWrapper &&
+          navWrapper.classList.contains("open")
+        ) {
+          closeMobileNav(true);
+        }
+      });
+
+      filiereView.addEventListener("click", (event) => {
+        const tile = event.target.closest(".tile");
+        if (!tile) return;
+        const { group: groupKey, filiere: filiereKey } = tile.dataset;
+        if (!groupKey || !filiereKey) return;
+        const label = tile.querySelector("h3")?.textContent?.trim() || "";
+        state.view = "modules";
+        state.group = groupKey;
+        state.filiere = filiereKey;
+        state.filiereLabel = label;
+        render();
+        scrollToSection(groupPanel);
+      });
+
+      breadcrumbHome.addEventListener("click", () => {
+        resetToHome();
+        window.scrollTo({ top: 0, behavior: "smooth" });
+        if (isMobileView()) {
+          closeMobileNav();
+        }
+      });
+
+      breadcrumbGroupBtn.addEventListener("click", () => {
+        if (!state.group) {
+          resetToHome();
+          return;
+        }
+        state.view = "filiere";
+        state.filiere = null;
+        state.filiereLabel = "";
+        render();
+        scrollToSection(groupPanel);
+      });
+
+      document.getElementById("year").textContent = new Date().getFullYear();
+      render();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- swap the header and footer branding to a CSS-rendered "FD" monogram so no binary logo file is required
- delete the PNG logo asset that caused GitHub to treat the branch as containing unsupported binary diffs

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e1986af7e8832695f5401c60cad358